### PR TITLE
revise output of buildinfo metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
 # orb: check opam package reproductibility
 
 This tool can check if an opam package build is reproductible (cf.
-https://reproducible-builds.org). It installs the package twice (different path
-& time) and check that installed files have the same hash.
+https://reproducible-builds.org). It has two subcommands: build and rebuild.
+
+The orb build conducts a build of an opam package, and collects the build result
+(and hashes thereof) and the build input (or build info), consisting of:
+- build-environment (the environment variables plus OS/OS_DISTRIBUTION/OS_FAMILY/OS_VERSION)
+- system-packages (the installed packages on the system)
+- opam-switch (opam switch export --full --freeze - a textual representation containing all installed opam packages)
+- *.build-hashes with maps of installed files to their hashes
+
+The orb rebuild takes this data as input and conducts a second build with the same environment, and compares that the hashes of the produced binaries are identical.
+
+The orb build also has a command-line flag "--twice" to conduct a build and a
+rebuild directly afterwards. For debugging reproducibility, a "--keep-build"
+(useful with opam's "--keep-build-dir") option is provided that allows to
+compare intermediate build products as well.
+
+Please have a look at "--diffoscope", "--out", "--switch-name",
+"--solver-timeout", "--date", and other command line parameters.
+
+It is currently used as a payload of
+[builder-worker](https://github.com/roburio/builder) to run the
+[reproducible MirageOS unikernels](https://builds.robur.coop) infrastructure.
+
+Binary packages for different platforms (Debian, Ubuntu, FreeBSD) are available
+at https://builds.robur.coop
 
 ## Install & use
 
 ```
-$ opam pin git+https://github.com/hannesm/orb#active
-$ orb pkg [--diiffoscope]
+$ opam pin git+https://github.com/roburio/orb#next
+$ orb build --twice --repos=default:https://opam.ocaml.org cmdliner
 ```
 
-This project is currently in early beta.
-
-## How does it work?
-
-`orb` uses an already installed `opam` & opam root, and it follows those steps:
-
-- Install of two new switches in `/tmp`
-- Install of packages dependencies
-- Install of required packages
-- Retrieves hashes of installed files and look for mismatches
-- Remove temporary switches
-
-With option `--diffoscope`, mismatching files are copied locally and their diff 
-generated, using [`diffoscope`](https://diffoscope.org/).
-
-As `orb` generates temporary switches, packages dependencies are installed each 
-time (also compiler), which can be time consuming when working on a package. 
-
-`--keep-switches`  option permit to keep those generated switches for 
-investigation needs. To manually remove them, don't just remove directory, but 
-use `opam switch remove <sw>`.
+Simple (and fast) failing and successful reproducible opam packages are in the
+[reproducible-testing-repo](https://github.com/roburio/reproducible-testing-repo).

--- a/orb.opam
+++ b/orb.opam
@@ -19,7 +19,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["sh" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
-  ["sh" "packaging/debian/create_package.sh"] {os-family = "debian"}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
 ]
 dev-repo: "git+https://github.com/roburio/orb.git"


### PR DESCRIPTION
Now, the build-environment, system-packages, and opam-switch are also output on build failure. NB: The opam switch is incomplete on build error, only the packages that were build are in the opam-switch (e.g. if building of foo fails, only foo's dependencies are in the opam-switch, not foo itself, and `root` is empty).

Also updates the README with the current state of this project and where it is used.